### PR TITLE
add iter.Seq2 method, refactor receiver name, add Iter() test

### DIFF
--- a/mightymap.go
+++ b/mightymap.go
@@ -107,10 +107,10 @@ func (m *Map[K, V]) Iter() iter.Seq2[K, V] {
 func (m *Map[K, V]) Pop(key K) (value V, ok bool) {
 	value, ok = m.storage.Load(key)
 	if !ok {
-		return value, ok
+		return
 	}
 	m.storage.Delete(key)
-	return value, true
+	return
 }
 
 // Next returns the next key-value pair from the map.

--- a/mightymap_test.go
+++ b/mightymap_test.go
@@ -92,4 +92,16 @@ func TestConcurrentMap_DefaultStorage(t *testing.T) {
 			t.Errorf("Expected map to be cleared")
 		}
 	})
+
+	t.Run("Iter", func(t *testing.T) {
+		cm.Store(2, "two")
+		cm.Store(3, "three")
+		keys := make(map[int]bool)
+		for k, _ := range cm.Iter() {
+			keys[k] = true
+		}
+		if len(keys) != 2 {
+			t.Errorf("Expected to iter over 2 keys, got %d", len(keys))
+		}
+	})
 }


### PR DESCRIPTION
Added Golang 1.23 iteration method for convenience. Small refactor of receiver name in Map methods. Added Iter() test case in default store test.